### PR TITLE
Fix feedback proxy context to prevent cancellation issues

### DIFF
--- a/internal/api/handlers/reactions.go
+++ b/internal/api/handlers/reactions.go
@@ -122,7 +122,7 @@ func (h *ReactionsHandler) UpsertReaction(c *gin.Context) {
 		return
 	}
 
-	h.proxyUpsertToPlatform(ctx, tenantCtx.TenantID, conversationID, messageID, middleware.GetToken(c), req)
+	h.proxyUpsertToPlatform(tenantCtx.TenantID, conversationID, messageID, middleware.GetToken(c), req)
 
 	c.JSON(http.StatusOK, h.toReactionResponse(reaction))
 }
@@ -163,7 +163,7 @@ func (h *ReactionsHandler) DeleteReaction(c *gin.Context) {
 		return
 	}
 
-	h.proxyDeleteToPlatform(ctx, tenantCtx.TenantID, middleware.SanitizePathParam(c, "conversationId"), messageID, middleware.GetToken(c))
+	h.proxyDeleteToPlatform(tenantCtx.TenantID, middleware.SanitizePathParam(c, "conversationId"), messageID, middleware.GetToken(c))
 
 	c.Status(http.StatusNoContent)
 }
@@ -325,7 +325,7 @@ func reactionToFeedbackRating(rt models.ReactionType) string {
 	return "THUMBS_DOWN"
 }
 
-func (h *ReactionsHandler) proxyUpsertToPlatform(ctx context.Context, tenantID, conversationID, messageID, authToken string, req UpsertReactionRequest) {
+func (h *ReactionsHandler) proxyUpsertToPlatform(tenantID, conversationID, messageID, authToken string, req UpsertReactionRequest) {
 	if h.platformClient == nil || authToken == "" {
 		return
 	}
@@ -340,7 +340,7 @@ func (h *ReactionsHandler) proxyUpsertToPlatform(ctx context.Context, tenantID, 
 	}
 	go func() {
 		defer func() { _ = recover() }()
-		bgCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := h.platformClient.UpsertMessageFeedback(bgCtx, tenantID, conversationID, messageID, authToken, payload); err != nil {
 			slog.Error("failed to proxy feedback upsert to platform",
@@ -354,13 +354,13 @@ func (h *ReactionsHandler) proxyUpsertToPlatform(ctx context.Context, tenantID, 
 	}()
 }
 
-func (h *ReactionsHandler) proxyDeleteToPlatform(ctx context.Context, tenantID, conversationID, messageID, authToken string) {
+func (h *ReactionsHandler) proxyDeleteToPlatform(tenantID, conversationID, messageID, authToken string) {
 	if h.platformClient == nil || authToken == "" {
 		return
 	}
 	go func() {
 		defer func() { _ = recover() }()
-		bgCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = h.platformClient.DeleteMessageFeedback(bgCtx, tenantID, conversationID, messageID, authToken)
 	}()


### PR DESCRIPTION
This pull request refactors the `ReactionsHandler` methods to simplify context management when proxying reaction upsert and delete operations to the platform service. The main change is the removal of the explicit `context.Context` parameter from internal proxy methods, ensuring that background operations use a fresh context with timeout, rather than inheriting the HTTP request context.

**Context management improvements:**

* Removed the `context.Context` parameter from `proxyUpsertToPlatform` and `proxyDeleteToPlatform` methods, so these now always use `context.Background()` with a timeout for background operations. [[1]](diffhunk://#diff-568ae5b6955b70f67ae0677ebe952edd4ba7eb85b4d1a0c5b3b57b8215520f98L328-R328) [[2]](diffhunk://#diff-568ae5b6955b70f67ae0677ebe952edd4ba7eb85b4d1a0c5b3b57b8215520f98L357-R363)
* Updated the goroutines in both proxy methods to create a new background context with timeout, instead of deriving from the original request context. This avoids potential issues with context cancellation when the HTTP request completes. [[1]](diffhunk://#diff-568ae5b6955b70f67ae0677ebe952edd4ba7eb85b4d1a0c5b3b57b8215520f98L343-R343) [[2]](diffhunk://#diff-568ae5b6955b70f67ae0677ebe952edd4ba7eb85b4d1a0c5b3b57b8215520f98L357-R363)

**API handler adjustments:**

* Updated `UpsertReaction` and `DeleteReaction` handlers to call the proxy methods without passing the request context, reflecting the new method signatures. [[1]](diffhunk://#diff-568ae5b6955b70f67ae0677ebe952edd4ba7eb85b4d1a0c5b3b57b8215520f98L125-R125) [[2]](diffhunk://#diff-568ae5b6955b70f67ae0677ebe952edd4ba7eb85b4d1a0c5b3b57b8215520f98L166-R166)